### PR TITLE
Fix Gleam's rebar config

### DIFF
--- a/apps/hello_gleam/gen/test/hello_gleam_test.erl
+++ b/apps/hello_gleam/gen/test/hello_gleam_test.erl
@@ -4,4 +4,4 @@
 -export([hello_test/0]).
 
 hello_test() ->
-    expect:equal(hello_gleam:hello(), <<"Hello from Gleam!o">>).
+    expect:equal(hello_gleam:hello(), <<"Hello from Gleam!">>).

--- a/apps/hello_gleam/rebar.config
+++ b/apps/hello_gleam/rebar.config
@@ -11,7 +11,7 @@
 {src_dirs, ["src", "gen/src"]}.
 
 {profiles, [
-    {test, [{src_dirs, ["test", "gen/test"]}]}
+    {test, [{src_dirs, ["src", "gen/src", "test", "gen/test"]}]}
 ]}.
 
 {pre_hooks, [{compile, "gleam build ."}]}.


### PR DESCRIPTION
Oops! The previous instructions on the Gleam website were incorrect. My
bad! This patch corrects the problem.